### PR TITLE
fix: 플러그인 설치 환경에서 스크립트 경로 참조 실패 수정

### DIFF
--- a/skills/tagging-definition/SKILL.md
+++ b/skills/tagging-definition/SKILL.md
@@ -299,7 +299,7 @@ PPT와 **동일한 데이터·표 기준**으로 .xlsx 생성. 시트 또는 영
 
 스킬의 **스크립트·데이터 형식**은 아래처럼 검증한다. **의존성은 실행 시 자동 설치**되므로 미리 `pip install` 할 필요 없다.
 
-1. **샘플 데이터로 엑셀 생성** (`{SKILL_DIR}` = 이 SKILL.md의 디렉토리 절대 경로):
+1. **샘플 데이터로 엑셀 생성**:
    ```bash
    python3 {SKILL_DIR}/scripts/run_generate.py xlsx \
      {SKILL_DIR}/scripts/태깅정의_데이터_샘플.md \


### PR DESCRIPTION
## 문제

다른 사용자가 Cursor 팀 마켓플레이스를 통해 플러그인을 설치한 뒤 태깅 정의 스킬을 사용하면, PPT/엑셀 생성 단계에서 스크립트를 찾지 못해 실패한다.

## 원인

SKILL.md의 스크립트 실행 명령이 **CWD 기준 상대 경로**를 하드코딩하고 있었다.

```bash
# 기존 (문제 있는 코드)
python3 skills/tagging-definition/scripts/run_generate.py pptx ...
```

| 항목 | 경로 |
|---|---|
| 플러그인 설치 위치 | `~/.cursor/plugins/product-toolkit/skills/tagging-definition/` |
| 사용자 프로젝트 CWD | `~/their-project/` |
| 기존 명령이 탐색하는 경로 | `~/their-project/skills/tagging-definition/scripts/` ❌ |

개발자 본인 환경(`C:\Users\surro\Toy\hanaplugin`)에서는 CWD가 플러그인 루트와 일치하므로 정상 동작했지만, 다른 사용자 환경에서는 해당 경로가 존재하지 않아 스크립트 실행 자체가 실패한다.

> **참고:** `generate_pptx.py` 내부는 `Path(__file__).resolve().parent` 기준으로 템플릿 경로를 탐색하도록 이미 올바르게 구현되어 있다. 스크립트만 실행되면 템플릿은 자동으로 찾는다.

## 수정 내용

스크립트 경로를 `{SKILL_DIR}` 플레이스홀더로 변경했다.

```bash
# 변경 후
python3 {SKILL_DIR}/scripts/run_generate.py pptx ...
```

`{SKILL_DIR}`은 Claude가 SKILL.md를 읽는 시점에 해당 파일의 절대 경로를 알고 있으므로, 실행 시 플러그인 설치 디렉토리의 절대 경로로 치환된다. 플러그인이 어느 위치에 설치되어도 동작한다.

아울러 `{SKILL_DIR}`의 의미를 Claude에게 명확히 전달하는 MANDATORY 설명을 추가해, 치환 규칙이 모호하게 해석되지 않도록 했다.

## 변경 파일

- `skills/tagging-definition/SKILL.md`
  - **실행 방법** 섹션: 상대경로 → `{SKILL_DIR}/scripts/...` + MANDATORY 치환 규칙 설명 추가
  - **테스트 방법** 1번: 상대경로 → `{SKILL_DIR}/scripts/...`
  - **테스트 방법** 2번: 상대경로 → `{SKILL_DIR}/scripts/...`

## 테스트 방법

플러그인 설치 디렉토리(`~/.cursor/plugins/product-toolkit/` 등)에서 SKILL.md를 확인한 뒤, 태깅 정의 스킬을 호출하여 PPT 생성 단계까지 진행 시 오류 없이 `.pptx` 파일이 생성되는지 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)